### PR TITLE
allow monaco-editor version ranges from 0.50.x to 0.52.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "vim-monaco",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vim-monaco",
-      "version": "1.0.0",
+      "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
         "microbundle": "^0.15.1",
-        "monaco-editor": "^0.50.0",
+        "monaco-editor": ">=0.50.0 <0.53.0",
         "typescript": "^5.5.3"
       },
       "peerDependencies": {
-        "monaco-editor": "0.50.0"
+        "monaco-editor": ">=0.50.0 <0.53.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   "license": "MIT",
   "devDependencies": {
     "microbundle": "^0.15.1",
-    "monaco-editor": "^0.50.0",
+    "monaco-editor": ">=0.50.0 <0.53.0",
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "monaco-editor": "^0.50.0"
+    "monaco-editor": ">=0.50.0 <0.53.0"
   }
 }


### PR DESCRIPTION
so I can use monaco 0.52.x in my project.

Awesome project, btw! I started using it in the Latex editor I'm working on called [Crixet](http://crixet.com/). Here's a quick demo of the new functionality: https://x.com/vicapow/status/1859016989551063427